### PR TITLE
Add **kwds to Bear.connect(), which are passed to sqlite3.connect()

### DIFF
--- a/bear/__init__.py
+++ b/bear/__init__.py
@@ -173,17 +173,18 @@ class Note(object):
 
 
 class Bear(object):
-    def __init__(self, path=None):
+    def __init__(self, path=None, *, connect=True):
         if path:
             self._path = path
         else:
             self._path = os.path.expanduser(
                 '~//Library/Containers/net.shinyfrog.bear/Data/Library'
                 '/Application Support/net.shinyfrog.bear/database.sqlite')
-        self.connect()
+        if connect:
+            self.connect()
 
-    def connect(self):
-        self._db = sqlite3.connect(self._path)
+    def connect(self, **kwds):
+        self._db = sqlite3.connect(self._path, **kwds)
         self._db.row_factory = sqlite3.Row
 
     def notes(self):


### PR DESCRIPTION
This is done to allow control over sqlite3.connect() arguments like
check_same_thread. Those arguments and sqlite3's behaviour are caller's
responsibility, so there is no provision to ensure locking etc.

Also connect= argument to __init__() is added, so the .connect() method
can actually be meaningfuly called. The argument defaults to True for
compatibility.

Intended usage:

```python
with lock:
    db = bear.Bear(path, connect=False)
    db.connect(check_same_thread=False)
```