### PR TITLE
Fix typo in SQL in get_note()

### DIFF
--- a/bear/__init__.py
+++ b/bear/__init__.py
@@ -246,7 +246,7 @@ class Bear(object):
     def get_note(self, id):
         cursor = self._db.cursor()
         cursor.execute(
-            'SELECT * FROM ZFSNOTE WHERE ZUNIQUEIDENTIFIER = ?', [id])
+            'SELECT * FROM ZSFNOTE WHERE ZUNIQUEIDENTIFIER = ?', [id])
         row = cursor.fetchone()
         if not row:
             return None

--- a/bear/__init__.py
+++ b/bear/__init__.py
@@ -26,7 +26,7 @@ import re
 import sqlite3
 import datetime
 
-__version__ = '0.0.20200629'
+__version__ = '0.0.20200914'
 
 def timestamp_to_datetime(s):
     '''


### PR DESCRIPTION
This is my fault. Sorry for this.

Bumped the version, so anyone who uses this would get the update.

You may consider merging this after #8, so the version bump commit is on top.