### PR TITLE
Fixed path to the sqlite database

### DIFF
--- a/bear/__init__.py
+++ b/bear/__init__.py
@@ -178,8 +178,8 @@ class Bear(object):
             self._path = path
         else:
             self._path = os.path.expanduser(
-                '~//Library/Containers/net.shinyfrog.bear/Data/Library'
-                '/Application Support/net.shinyfrog.bear/database.sqlite')
+                '~/Library/Group Containers/9K33E3U3T4.net.shinyfrog.bear'
+                '/Application Data/database.sqlite')
         if connect:
             self.connect()
 


### PR DESCRIPTION
Fix the location of the sqlite database as mentioned in [Bear documentation](https://bear.app/faq/Where%20are%20Bear's%20notes%20located/#:~:text=On%20both%20iOS%20and%20macOS,library%20that%20has%20SQLite%20support.).